### PR TITLE
[youtube] v2.5 -> v2.6

### DIFF
--- a/YouTube/YouTube.user.css
+++ b/YouTube/YouTube.user.css
@@ -3,7 +3,7 @@
 @namespace      USO Archive
 @author         sprince0031
 @description    `<p bgcolor="#000" color="#fff"><u><b>*TURN ON DARK MODE IN YOUTUBE BEFORE APPLYING THIS THEME*</b></u></p>Inspired by the legendary PitchBlack Substratum theme for Android, this is a PitchBlack theme for YouTube. In true PitchBlack fashion, you get to pick the accent color of your choice! A list of all PitchBlack accents and background variants are available below along with their hexcodes. Do note that you can pick any color you want from the color picker but these are the official colors. Enjoy!*P.S Pssst..!! Do rate and share the theme if you liked it. :D`
-@version        20260112.2.5
+@version        20260428.2.6
 @homepageURL	https://github.com/sprince0031/PitchBlack-UserStyle-themes
 @supportURL	https://github.com/sprince0031/PitchBlack-UserStyle-themes/issues
 @license        CC-BY-SA-4.0
@@ -189,7 +189,8 @@ ytd-feed-filter-chip-bar-renderer #chips-wrapper.ytd-feed-filter-chip-bar-render
         --paper-tabs-selection-bar-color: /*[[color]]*/
         !important;
         --yt-spec-static-overlay-background-brand: /*[[color]]*/ !important;
-				--default-white-colour: #eee;
+		--default-white-colour: #eee;
+		--yt-spec-text-primary: var(--default-white-colour);
     }
 
     html,
@@ -259,6 +260,12 @@ ytd-feed-filter-chip-bar-renderer #chips-wrapper.ytd-feed-filter-chip-bar-render
         background: /*[[color]]*/;
     }
   
+	/* Category chip elements */
+	.ytChipShapeActive {
+		background-color: /*[[color]]*/;
+		color: /*[[bg]]*/;
+	}
+		
   
     /*   voice search   */
     #voice-search-button yt-icon-shape svg,
@@ -1534,8 +1541,21 @@ ytd-feed-filter-chip-bar-renderer #chips-wrapper.ytd-feed-filter-chip-bar-render
         !important;
     }
 	
+	.ytLockupMetadataViewModelMetadata div:first-child {
+		color: /*[[color]]*/;
+	}
+
+	.ytBadgeShapeDefault {
+		background: /*[[color]]*/ !important;
+	}
+
+	.ytContentMetadataViewModelBadge .ytBadgeShapeText {
+		color: /*[[bg]]*/ !important;
+	}
+	
     /* Home page individual items */
-    .yt-lockup-metadata-view-model__text-container h3 a {
+    .ytLockupMetadataViewModelHeadingReset a,
+	.shortsLockupViewModelHostMetadataTitle a {
         color: var(--default-white-colour) !important;
     }
 }

--- a/YouTube/changelog.md
+++ b/YouTube/changelog.md
@@ -1,4 +1,8 @@
 # Changelog:
+### v2.6
+- Fixed video titles being displayed ion accent colour instead of white.
+- Fixed active chip UI elements for content cateogories not being themed.
+  
 ### v2.5
 - Fixed theming for YouTube logo elements to ensure consistent accent color application.
 - Updated subscribe button styling for Shorts player with proper accent color and hover effects.


### PR DESCRIPTION
This pull request updates the PitchBlack YouTube userstyle to version 2.6, focusing on fixing theming issues for video titles and active chip UI elements. The changes ensure that video titles are displayed in white rather than the accent color, and that active content category chips are properly themed with the selected accent and background colors.

Bug fixes and theming improvements:

* Fixed video titles to display in white (`var(--default-white-colour)`) instead of the accent color by updating selectors for video and Shorts titles.
* Themed active content category chip elements (`.ytChipShapeActive`) to use the selected accent color for the background and the background color for text, ensuring proper visibility and consistency.
* Added theming for metadata and badge elements, ensuring accent and background colors are applied consistently to metadata and badge text.
* Added a new CSS variable `--yt-spec-text-primary` set to the default white color to standardize text color usage.

Documentation:

* Updated the changelog (`changelog.md`) to reflect the bug fixes and improvements in version 2.6.

Versioning:

* Bumped the userstyle version to `20260428.2.6` in the metadata.